### PR TITLE
Enhance product filtering and navigation in FilterPanel

### DIFF
--- a/thryft/lib/providers/search_provider.dart
+++ b/thryft/lib/providers/search_provider.dart
@@ -9,7 +9,12 @@ import 'package:thryft/models/product.dart';
 class SearchFilters {
   final String? size;
   final String? category;
+  final String? department;
+  final String? brand;
   final String? condition;
+  final String? fitting;
+  final String? material;
+  final String? colour;
   final double? minPrice;
   final double? maxPrice;
   final String sortBy; // 'newest', 'price_asc', 'price_desc'
@@ -17,7 +22,12 @@ class SearchFilters {
   const SearchFilters({
     this.size,
     this.category,
+    this.department,
+    this.brand,
     this.condition,
+    this.fitting,
+    this.material,
+    this.colour,
     this.minPrice,
     this.maxPrice,
     this.sortBy = 'newest',
@@ -27,7 +37,12 @@ class SearchFilters {
   SearchFilters copyWith({
     Object? size = _sentinel,
     Object? category = _sentinel,
+    Object? department = _sentinel,
+    Object? brand = _sentinel,
     Object? condition = _sentinel,
+    Object? fitting = _sentinel,
+    Object? material = _sentinel,
+    Object? colour = _sentinel,
     Object? minPrice = _sentinel,
     Object? maxPrice = _sentinel,
     String? sortBy,
@@ -35,7 +50,12 @@ class SearchFilters {
     return SearchFilters(
       size: size == _sentinel ? this.size : size as String?,
       category: category == _sentinel ? this.category : category as String?,
+      department: department == _sentinel ? this.department : department as String?,
+      brand: brand == _sentinel ? this.brand : brand as String?,
       condition: condition == _sentinel ? this.condition : condition as String?,
+      fitting: fitting == _sentinel ? this.fitting : fitting as String?,
+      material: material == _sentinel ? this.material : material as String?,
+      colour: colour == _sentinel ? this.colour : colour as String?,
       minPrice: minPrice == _sentinel ? this.minPrice : minPrice as double?,
       maxPrice: maxPrice == _sentinel ? this.maxPrice : maxPrice as double?,
       sortBy: sortBy ?? this.sortBy,
@@ -46,7 +66,12 @@ class SearchFilters {
   bool get hasActiveFilters =>
       size != null ||
       category != null ||
+      department != null ||
+      brand != null ||
       condition != null ||
+      fitting != null ||
+      material != null ||
+      colour != null ||
       minPrice != null ||
       maxPrice != null ||
       sortBy != 'newest';

--- a/thryft/lib/screens/filter_results_screen.dart
+++ b/thryft/lib/screens/filter_results_screen.dart
@@ -23,10 +23,16 @@ class _FilterResultsScreenState extends State<FilterResultsScreen> {
 
   Future<List<Product>> _fetchFiltered() async {
     try {
+      final currentUserId = Supabase.instance.client.auth.currentUser?.id;
       var query = Supabase.instance.client
           .from('products')
           .select('*, profiles(username)')
           .eq('is_sold', false);
+
+      // exclude current user's items if we have a logged-in user
+      if (currentUserId != null) {
+        query = query.neq('user_id', currentUserId);
+      }
 
       final f = widget.filters;
       if (f.department != null) query = query.eq('department', f.department!);
@@ -51,7 +57,7 @@ class _FilterResultsScreenState extends State<FilterResultsScreen> {
           data = await query.order('created_at', ascending: false);
       }
 
-      return (data as List).map((row) => Product(
+      return (data).map((row) => Product(
         id: row['id'].toString(),
         name: row['name'].toString(),
         price: (row['price'] as num).toDouble(),

--- a/thryft/lib/screens/filter_results_screen.dart
+++ b/thryft/lib/screens/filter_results_screen.dart
@@ -1,0 +1,111 @@
+import 'package:flutter/material.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:thryft/models/product.dart';
+import 'package:thryft/widgets/standard_product_grid.dart';
+import 'package:thryft/providers/search_provider.dart';
+
+class FilterResultsScreen extends StatefulWidget {
+  final SearchFilters filters;
+  const FilterResultsScreen({super.key, required this.filters});
+
+  @override
+  State<FilterResultsScreen> createState() => _FilterResultsScreenState();
+}
+
+class _FilterResultsScreenState extends State<FilterResultsScreen> {
+  late Future<List<Product>> _resultsFuture;
+
+  @override
+  void initState() {
+    super.initState();
+    _resultsFuture = _fetchFiltered();
+  }
+
+  Future<List<Product>> _fetchFiltered() async {
+    try {
+      var query = Supabase.instance.client
+          .from('products')
+          .select('*, profiles(username)')
+          .eq('is_sold', false);
+
+      final f = widget.filters;
+      if (f.department != null) query = query.eq('department', f.department!);
+      if (f.size != null) query = query.eq('size', f.size!);
+      if (f.brand != null) query = query.eq('brand', f.brand!);
+      if (f.condition != null) query = query.eq('condition', f.condition!);
+      if (f.fitting != null) query = query.eq('fitting', f.fitting!);
+      if (f.material != null) query = query.eq('material', f.material!);
+      if (f.colour != null) query = query.eq('colour', f.colour!);
+      if (f.minPrice != null) query = query.gte('price', f.minPrice!);
+      if (f.maxPrice != null) query = query.lte('price', f.maxPrice!);
+
+      List data;
+      switch (f.sortBy) {
+        case 'price_asc':
+          data = await query.order('price', ascending: true);
+          break;
+        case 'price_desc':
+          data = await query.order('price', ascending: false);
+          break;
+        default:
+          data = await query.order('created_at', ascending: false);
+      }
+
+      return (data as List).map((row) => Product(
+        id: row['id'].toString(),
+        name: row['name'].toString(),
+        price: (row['price'] as num).toDouble(),
+        originalPrice: row['original_price'] != null ? (row['original_price'] as num).toDouble() : null,
+        size: row['size']?.toString() ?? '',
+        brand: row['brand']?.toString() ?? '',
+        condition: row['condition']?.toString() ?? '',
+        imageUrl: row['image_url']?.toString(),
+        sellerId: row['user_id']?.toString(),
+        sellerName: row['profiles'] != null ? row['profiles']['username']?.toString() : null,
+        category: row['category']?.toString() ?? 'Other',
+        department: row['department']?.toString() ?? 'All',
+        createdAt: row['created_at'] != null ? DateTime.tryParse(row['created_at'].toString()) : null,
+        material: row['material']?.toString() ?? '',
+        colour: row['colour']?.toString() ?? '',
+        isSold: row['is_sold'] == true,
+      )).toList();
+    } catch (e) {
+      debugPrint('Filter query error: $e');
+      return [];
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Filter results'),
+      ),
+      body: FutureBuilder<List<Product>>(
+        future: _resultsFuture,
+        builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const SizedBox(height: 300, child: Center(child: CircularProgressIndicator()));
+          }
+          if (snapshot.hasError) {
+            return Center(child: Text('Error: ${snapshot.error}'));
+          }
+
+          final items = snapshot.data ?? [];
+          return SingleChildScrollView(
+            child: Column(
+              children: [
+                StandardProductGrid(
+                  items: items,
+                  emptyIcon: Icons.search_off,
+                  emptyTitle: 'No results',
+                  emptySubtitle: 'No items match your selected filters.',
+                ),
+              ],
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/thryft/lib/screens/product_detail_screen.dart
+++ b/thryft/lib/screens/product_detail_screen.dart
@@ -202,6 +202,8 @@ class ProductDetailScreen extends StatelessWidget {
         const SizedBox(height: 16),
         _buildDetailRow("Brand", product['brand'] ?? '-', isLink: true),
         const SizedBox(height: 12),
+        _buildDetailRow("Department", product['department'] ?? '-'),
+        const SizedBox(height: 12),
         _buildDetailRow("Size", product['size'] ?? '-'),
         const SizedBox(height: 12),
         _buildDetailRow("Condition", product['condition'] ?? '-'),

--- a/thryft/lib/widgets/filter_system.dart
+++ b/thryft/lib/widgets/filter_system.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:thryft/utils/size_options.dart';
 import 'package:thryft/providers/search_provider.dart'; // new import
+import 'package:thryft/screens/filter_results_screen.dart'; // added import
 
 class FilterPanel extends StatefulWidget {
   const FilterPanel({super.key, this.onApply});
@@ -169,6 +170,13 @@ class _FilterPanelState extends State<FilterPanel> {
                           sortBy: 'newest',
                         );
                         widget.onApply?.call(filters);
+
+                        // navigate to the filter results screen
+                        Navigator.of(context).push(
+                          MaterialPageRoute(
+                            builder: (context) => FilterResultsScreen(filters: filters),
+                          ),
+                        );
                       },
                       child: const Text('Apply'),
                     ),

--- a/thryft/lib/widgets/filter_system.dart
+++ b/thryft/lib/widgets/filter_system.dart
@@ -157,9 +157,13 @@ class _FilterPanelState extends State<FilterPanel> {
                             ? null
                             : double.tryParse(_priceController.text.trim());
                         final filters = SearchFilters(
+                          department: _department == 'All' ? null : _department,
                           size: _size == 'All' ? null : _size,
-                          category: null, // keep department logic unchanged for now
+                          brand: _brands == 'All' ? null : _brands,
                           condition: _condition == 'All' ? null : _condition,
+                          fitting: _fitting == 'All' ? null : _fitting,
+                          material: _material == 'All' ? null : _material,
+                          colour: _colour == 'All' ? null : _colour,
                           minPrice: null,
                           maxPrice: maxPrice,
                           sortBy: 'newest',

--- a/thryft/lib/widgets/filter_system.dart
+++ b/thryft/lib/widgets/filter_system.dart
@@ -1,9 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:thryft/utils/size_options.dart';
+import 'package:thryft/providers/search_provider.dart'; // new import
 
 class FilterPanel extends StatefulWidget {
   const FilterPanel({super.key, this.onApply});
-  final ValueChanged<Map<String, String>>? onApply;
+  final ValueChanged<SearchFilters>? onApply; // changed type
 
   @override
   State<FilterPanel> createState() => _FilterPanelState();
@@ -151,16 +152,20 @@ class _FilterPanelState extends State<FilterPanel> {
                     ),
 
                     TextButton(
-                      onPressed: () => widget.onApply?.call({
-                        'department': _department,
-                        'size': _size,
-                        'brand': _brands,
-                        'price': _priceController.text.trim(),
-                        'condition': _condition,
-                        'fitting': _fitting,
-                        'material': _material,
-                        'colour': _colour,
-                      }),
+                      onPressed: () {
+                        final maxPrice = _priceController.text.trim().isEmpty
+                            ? null
+                            : double.tryParse(_priceController.text.trim());
+                        final filters = SearchFilters(
+                          size: _size == 'All' ? null : _size,
+                          category: null, // keep department logic unchanged for now
+                          condition: _condition == 'All' ? null : _condition,
+                          minPrice: null,
+                          maxPrice: maxPrice,
+                          sortBy: 'newest',
+                        );
+                        widget.onApply?.call(filters);
+                      },
                       child: const Text('Apply'),
                     ),
 


### PR DESCRIPTION
This pull request adds significant improvements to the search and filter functionality in the app. It introduces a new `FilterResultsScreen` to display filtered products, expands the `SearchFilters` model with more filter options, and updates the filter UI and logic to support these changes. Additionally, product details now show the department field.

**Search and Filter Enhancements:**

* Added a new `FilterResultsScreen` (`thryft/lib/screens/filter_results_screen.dart`) that fetches and displays products matching the selected filters, including support for department, brand, fitting, material, colour, and price range. The screen also sorts results and excludes the current user's items.
* Expanded the `SearchFilters` class in `search_provider.dart` to include new fields: `department`, `brand`, `fitting`, `material`, and `colour`. Updated the constructor, `copyWith` method, and `hasActiveFilters` getter to support these fields.

**UI and Integration Updates:**

* Updated the filter system (`filter_system.dart`) to use the new `SearchFilters` model, and changed the filter application logic to instantiate `SearchFilters` and navigate to the new `FilterResultsScreen` when filters are applied.
* Enhanced the product detail screen to display the product's department field.