### PR TITLE
Fix: Remove sold items from all users' carts on checkout

### DIFF
--- a/thryft/lib/providers/cart_provider.dart
+++ b/thryft/lib/providers/cart_provider.dart
@@ -43,7 +43,8 @@ class CartProvider extends ChangeNotifier {
           final productsData = await Supabase.instance.client
               .from('products')
               .select('*, profiles(username)')
-              .inFilter('id', productIds);
+              .inFilter('id', productIds)
+              .eq('is_sold', false);
               
           for (var pData in productsData) {
             final product = Product(

--- a/thryft/lib/screens/cart_screen.dart
+++ b/thryft/lib/screens/cart_screen.dart
@@ -71,6 +71,12 @@ class _CartScreenState extends State<CartScreen> {
           'buyer_id': user.id,
           'order_status': 'pending',
         }).eq('id', item.product.id);
+
+        // Remove this product from all users' carts
+        await Supabase.instance.client
+            .from('cart_items')
+            .delete()
+            .eq('product_id', item.product.id);
       }
     } catch (e) {
       debugPrint('Error marking checkout items as sold: $e');


### PR DESCRIPTION
Fixes the bug where purchasing a product left it visible in other users' carts.

Closes #119.

### Changes

**Delete cart entries for purchased products on checkout (`cart_screen.dart`)**
- After marking a product as sold, all `cart_items` rows for that product are deleted across all users.
- This ensures the item instantly disappears from every other buyer's cart database record.

**Exclude sold products when loading cart (`cart_provider.dart`)**
- Added `.eq('is_sold', false)` filter to the product fetch query in `CartProvider`.
- Acts as a safety net: if a product was sold between sessions, it won't reappear on next cart load.

### Verification
- `dart analyze lib/` — zero errors.