### PR TITLE
Require payment method for checkout and listing creation

### DIFF
--- a/thryft/lib/screens/cart_screen.dart
+++ b/thryft/lib/screens/cart_screen.dart
@@ -60,6 +60,33 @@ class _CartScreenState extends State<CartScreen> {
       return;
     }
 
+    try {
+      final paymentData = await Supabase.instance.client
+          .from('payment_methods')
+          .select()
+          .eq('user_id', user.id)
+          .maybeSingle();
+
+      if (paymentData == null) {
+        if (mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(
+              content: Text('Please add a payment method in your profile settings before checkout.'),
+            ),
+          );
+        }
+        return;
+      }
+    } catch (e) {
+      debugPrint('Error fetching payment method: $e');
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Error verifying payment method.')),
+        );
+      }
+      return;
+    }
+
     setState(() => _isProcessingCheckout = true);
 
     final cartItems = List.from(cart.items);

--- a/thryft/lib/screens/create_listing_screen.dart
+++ b/thryft/lib/screens/create_listing_screen.dart
@@ -164,6 +164,25 @@ class _CreateListingScreenState extends State<CreateListingScreen> {
         throw Exception('You must be logged in to modify a listing.');
       }
 
+      // Verify user has a payment method before allowing them to list
+      final paymentData = await supabase
+          .from('payment_methods')
+          .select()
+          .eq('user_id', user.id)
+          .maybeSingle();
+
+      if (paymentData == null) {
+        if (mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(
+              content: Text('Please add a payment method in your profile settings before creating a listing.'),
+            ),
+          );
+          setState(() => _isLoading = false);
+        }
+        return;
+      }
+
       String? publicImageUrl = widget.initialData?['imageUrl'];
 
       // Upload main image if changed

--- a/thryft/lib/screens/profile_settings_screen.dart
+++ b/thryft/lib/screens/profile_settings_screen.dart
@@ -19,6 +19,7 @@ class _ProfileSettingsScreenState extends State<ProfileSettingsScreen> {
   bool _isLoading = false;
 
   Map<String, dynamic>? _userAddress;
+  Map<String, dynamic>? _userPaymentMethod;
   String? _currentAvatarUrl;
   final _bioController = TextEditingController();
 
@@ -26,6 +27,7 @@ class _ProfileSettingsScreenState extends State<ProfileSettingsScreen> {
   void initState() {
     super.initState();
     _fetchAddress();
+    _fetchPaymentMethod();
     _fetchProfile();
   }
 
@@ -49,6 +51,27 @@ class _ProfileSettingsScreenState extends State<ProfileSettingsScreen> {
       if (mounted) {
         setState(() {
           _userAddress = response;
+        });
+      }
+    } catch (e) {
+      // Ignore if not present
+    }
+  }
+
+  Future<void> _fetchPaymentMethod() async {
+    final user = _supabase.auth.currentUser;
+    if (user == null) return;
+
+    try {
+      final response = await _supabase
+          .from('payment_methods')
+          .select()
+          .eq('user_id', user.id)
+          .maybeSingle();
+
+      if (mounted) {
+        setState(() {
+          _userPaymentMethod = response;
         });
       }
     } catch (e) {

--- a/thryft/lib/screens/profile_settings_screen.dart
+++ b/thryft/lib/screens/profile_settings_screen.dart
@@ -233,6 +233,41 @@ class _ProfileSettingsScreenState extends State<ProfileSettingsScreen> {
     }
   }
 
+  Future<void> _updatePaymentMethod(
+    String cardholderName,
+    String cardNumber,
+    String expiryDate,
+    String cvv,
+  ) async {
+    setState(() => _isLoading = true);
+    try {
+      final user = _supabase.auth.currentUser;
+      if (user == null) return;
+
+      final Map<String, dynamic> data = {
+        'user_id': user.id,
+        'cardholder_name': cardholderName,
+        'card_number': cardNumber,
+        'expiry_date': expiryDate,
+        'cvv': cvv,
+      };
+
+      if (_userPaymentMethod != null && _userPaymentMethod!.containsKey('id')) {
+        data['id'] = _userPaymentMethod!['id'];
+      }
+
+      await _supabase.from('payment_methods').upsert(data);
+      _showSnackBar('Successfully updated payment method');
+      await _fetchPaymentMethod();
+    } catch (e) {
+      _showSnackBar('Error: ${e.toString()}', isError: true);
+    } finally {
+      if (mounted) {
+        setState(() => _isLoading = false);
+      }
+    }
+  }
+
   void _showAddressDialog() {
     final streetCtrl = TextEditingController(
       text: _userAddress?['street'] ?? '',
@@ -314,6 +349,102 @@ class _ProfileSettingsScreenState extends State<ProfileSettingsScreen> {
                     cityCtrl.text.trim(),
                     postalCtrl.text.trim(),
                     countryCtrl.text.trim(),
+                  );
+                }
+              },
+              child: const Text('Save'),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  void _showPaymentDialog() {
+    final nameCtrl = TextEditingController(
+      text: _userPaymentMethod?['cardholder_name'] ?? '',
+    );
+    final numberCtrl = TextEditingController(
+      text: _userPaymentMethod?['card_number'] ?? '',
+    );
+    final expiryCtrl = TextEditingController(
+      text: _userPaymentMethod?['expiry_date'] ?? '',
+    );
+    final cvvCtrl = TextEditingController(
+      text: _userPaymentMethod?['cvv'] ?? '',
+    );
+    final formKey = GlobalKey<FormState>();
+
+    showDialog(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          title: const Text('Edit Payment Method'),
+          content: SingleChildScrollView(
+            child: Form(
+              key: formKey,
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  TextFormField(
+                    controller: nameCtrl,
+                    decoration: const InputDecoration(
+                      labelText: 'Cardholder Name',
+                      border: OutlineInputBorder(),
+                    ),
+                    validator: (val) =>
+                        val == null || val.trim().isEmpty ? 'Required' : null,
+                  ),
+                  const SizedBox(height: 12),
+                  TextFormField(
+                    controller: numberCtrl,
+                    decoration: const InputDecoration(
+                      labelText: 'Card Number',
+                      border: OutlineInputBorder(),
+                    ),
+                    keyboardType: TextInputType.number,
+                    validator: (val) =>
+                        val == null || val.trim().isEmpty ? 'Required' : null,
+                  ),
+                  const SizedBox(height: 12),
+                  TextFormField(
+                    controller: expiryCtrl,
+                    decoration: const InputDecoration(
+                      labelText: 'Expiry Date (MM/YY)',
+                      border: OutlineInputBorder(),
+                    ),
+                    validator: (val) =>
+                        val == null || val.trim().isEmpty ? 'Required' : null,
+                  ),
+                  const SizedBox(height: 12),
+                  TextFormField(
+                    controller: cvvCtrl,
+                    decoration: const InputDecoration(
+                      labelText: 'CVV',
+                      border: OutlineInputBorder(),
+                    ),
+                    keyboardType: TextInputType.number,
+                    validator: (val) =>
+                        val == null || val.trim().isEmpty ? 'Required' : null,
+                  ),
+                ],
+              ),
+            ),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(context),
+              child: const Text('Cancel'),
+            ),
+            ElevatedButton(
+              onPressed: () async {
+                if (formKey.currentState!.validate()) {
+                  Navigator.pop(context);
+                  await _updatePaymentMethod(
+                    nameCtrl.text.trim(),
+                    numberCtrl.text.trim(),
+                    expiryCtrl.text.trim(),
+                    cvvCtrl.text.trim(),
                   );
                 }
               },
@@ -640,6 +771,41 @@ class _ProfileSettingsScreenState extends State<ProfileSettingsScreen> {
                               ),
                               subtitle: Text(
                                 _userAddress?['country'] ?? 'Not set',
+                              ),
+                            ),
+                          ),
+                          const SizedBox(height: 32),
+                          Row(
+                            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                            children: [
+                              const Text(
+                                'Payment Method',
+                                style: TextStyle(
+                                  fontSize: 24,
+                                  fontWeight: FontWeight.bold,
+                                ),
+                              ),
+                              IconButton(
+                                icon: const Icon(
+                                  Icons.edit,
+                                  color: Colors.blue,
+                                ),
+                                onPressed: _showPaymentDialog,
+                              ),
+                            ],
+                          ),
+                          const SizedBox(height: 24),
+                          Card(
+                            child: ListTile(
+                              leading: const Icon(Icons.credit_card, size: 32),
+                              title: Text(
+                                _userPaymentMethod?['cardholder_name'] ?? 'Not set',
+                                style: const TextStyle(fontWeight: FontWeight.bold),
+                              ),
+                              subtitle: Text(
+                                _userPaymentMethod?['card_number'] != null
+                                    ? '**** **** **** ${_userPaymentMethod!['card_number'].toString().length >= 4 ? _userPaymentMethod!['card_number'].toString().substring(_userPaymentMethod!['card_number'].toString().length - 4) : _userPaymentMethod!['card_number']}'
+                                    : 'No card added',
                               ),
                             ),
                           ),


### PR DESCRIPTION
## Summary
Closes #122

Users must now have a saved payment method before they can checkout or create a new listing, just like the existing address requirement.

## Changes
- **Database**: Created `payment_methods` table in Supabase with Row Level Security (RLS)
- **Profile Settings**: Added UI section to add/edit credit card details (cardholder name, card number, expiry date, CVV) with masked card display
- **Cart Screen**: Checkout is blocked with a SnackBar if no payment method is saved
- **Create Listing Screen**: Listing submission is blocked with a SnackBar if no payment method is saved

## Testing
- `dart analyze lib/` passes with 0 errors
- Manual testing: verified checkout and listing creation are blocked without a payment method and succeed with one