### PR TITLE
Add seedNotification helper and refactor order status tests

### DIFF
--- a/thryft/test/fr6_track_orders/order_status_repository_test.dart
+++ b/thryft/test/fr6_track_orders/order_status_repository_test.dart
@@ -10,8 +10,11 @@ const _sellerPassword = 'Thryft!test99';
 const _buyerEmail = 'fr6.buyer@thryft-test.local';
 const _buyerPassword = 'Thryft!test99';
 
+// Uses the admin client to create the user when they don't exist yet,
+// bypassing email confirmation and avoiding rate limits.
 Future<String> _signInOrSignUp(
   SupabaseClient client,
+  SupabaseClient admin,
   String email,
   String password,
   String username,
@@ -23,10 +26,15 @@ Future<String> _signInOrSignUp(
     );
     return res.user!.id;
   } on AuthException {
-    final res = await client.auth.signUp(
+    await admin.auth.admin.createUser(AdminUserAttributes(
       email: email,
       password: password,
-      data: {'username': username},
+      emailConfirm: true,
+      userMetadata: {'username': username},
+    ));
+    final res = await client.auth.signInWithPassword(
+      email: email,
+      password: password,
     );
     return res.user!.id;
   }
@@ -51,12 +59,12 @@ void main() {
     admin = getServiceClient();
 
     sellerId = await _signInOrSignUp(
-        client, _sellerEmail, _sellerPassword, 'fr6_seller');
+        client, admin, _sellerEmail, _sellerPassword, 'fr6_seller');
     buyerId = await _signInOrSignUp(
-        client, _buyerEmail, _buyerPassword, 'fr6_buyer');
+        client, admin, _buyerEmail, _buyerPassword, 'fr6_buyer');
 
     // Run tests as the seller so RLS allows product reads.
-    await _signInOrSignUp(client, _sellerEmail, _sellerPassword, 'fr6_seller');
+    await _signInOrSignUp(client, admin, _sellerEmail, _sellerPassword, 'fr6_seller');
 
     repo = OrderRepository(client);
   });

--- a/thryft/test/fr6_track_orders/order_status_repository_test.dart
+++ b/thryft/test/fr6_track_orders/order_status_repository_test.dart
@@ -1,229 +1,254 @@
-import 'dart:async';
-
 import 'package:flutter_test/flutter_test.dart';
-import 'package:mocktail/mocktail.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 import 'package:thryft/repositories/order_repository.dart';
+import '../helpers/supabase_test_client.dart';
+import '../helpers/seed_helper.dart';
 
-// Mocks
+const _sellerEmail = 'fr6.seller@thryft-test.local';
+const _sellerPassword = 'Thryft!test99';
 
-class MockSupabaseClient extends Mock implements SupabaseClient {}
+const _buyerEmail = 'fr6.buyer@thryft-test.local';
+const _buyerPassword = 'Thryft!test99';
 
-class MockGoTrueClient extends Mock implements GoTrueClient {}
-
-class MockSupabaseQueryBuilder extends Mock implements SupabaseQueryBuilder {}
-
-// Fake select filter builder — same pattern as FR5 order_repository_test.
-
-class FakeSelectFilterBuilder extends Fake
-    implements PostgrestFilterBuilder<PostgrestList> {
-  final List<dynamic> _rows;
-
-  FakeSelectFilterBuilder(this._rows);
-
-  @override
-  FakeSelectFilterBuilder eq(String column, dynamic value) => this;
-
-  @override
-  FakeSelectFilterBuilder order(
-    String column, {
-    bool ascending = false,
-    bool nullsFirst = false,
-    String? referencedTable,
-  }) =>
-      this;
-
-  @override
-  Future<U> then<U>(
-    FutureOr<U> Function(PostgrestList value) onValue, {
-    Function? onError,
-  }) =>
-      Future.value(List<PostgrestMap>.from(_rows)).then(
-        onValue,
-        onError: onError,
-      );
-}
-
-// Helper — build a minimal raw DB row map
-
-Map<String, dynamic> _row({
-  String id = 'product-1',
-  String? name = 'Blue Jacket',
-  double price = 20.0,
-  String userId = 'seller-1',
-  String? buyerId = 'buyer-1',
-  bool isSold = true,
-  String? orderStatus = 'pending',
-  String? createdAt = '2026-01-01T00:00:00.000Z',
-}) =>
-    {
-      'id': id,
-      'name': name,
-      'price': price,
-      'original_price': null,
-      'size': 'M',
-      'brand': 'Nike',
-      'condition': 'Good',
-      'image_url': null,
-      'user_id': userId,
-      'profiles': {'username': 'seller_user'},
-      'is_sold': isSold,
-      'department': 'Menswear',
-      'category': 'Tops',
-      'material': 'Cotton',
-      'colour': 'Blue',
-      'buyer_id': buyerId,
-      'order_status': orderStatus,
-      'created_at': createdAt,
-      'description': null,
-    };
-
-// Stub helpers
-
-void _stubSelect(
-  MockSupabaseClient client,
-  MockSupabaseQueryBuilder qb,
-  List<dynamic> rows,
-) {
-  when(() => client.from(any())).thenAnswer((_) => qb);
-  when(() => qb.select(any()))
-      .thenAnswer((_) => FakeSelectFilterBuilder(rows));
+Future<String> _signInOrSignUp(
+  SupabaseClient client,
+  String email,
+  String password,
+  String username,
+) async {
+  try {
+    final res = await client.auth.signInWithPassword(
+      email: email,
+      password: password,
+    );
+    return res.user!.id;
+  } on AuthException {
+    final res = await client.auth.signUp(
+      email: email,
+      password: password,
+      data: {'username': username},
+    );
+    return res.user!.id;
+  }
 }
 
 void main() {
-  late MockSupabaseClient client;
-  late MockSupabaseQueryBuilder qb;
-  late OrderRepository repo;
+  if (!hasTestCredentials) {
+    test('FR6 integration tests', () {},
+        skip: 'No Supabase credentials — pass '
+            '--dart-define=TEST_SUPABASE_URL and TEST_SUPABASE_ANON_KEY to run');
+    return;
+  }
 
-  setUp(() {
-    client = MockSupabaseClient();
-    qb = MockSupabaseQueryBuilder();
+  late SupabaseClient client;
+  late SupabaseClient admin;
+  late OrderRepository repo;
+  late String sellerId;
+  late String buyerId;
+
+  setUpAll(() async {
+    client = await getTestClient();
+    admin = getServiceClient();
+
+    sellerId = await _signInOrSignUp(
+        client, _sellerEmail, _sellerPassword, 'fr6_seller');
+    buyerId = await _signInOrSignUp(
+        client, _buyerEmail, _buyerPassword, 'fr6_buyer');
+
+    // Run tests as the seller so RLS allows product reads.
+    await _signInOrSignUp(client, _sellerEmail, _sellerPassword, 'fr6_seller');
+
     repo = OrderRepository(client);
   });
 
+  tearDownAll(() async {
+    await admin.from('products').delete().eq('user_id', sellerId);
+    await client.auth.signOut();
+  });
+
+  // ---------------------------------------------------------------------------
   // FR6 Partition 1 — Valid purchase: item marked as sold with pending status
+  // ---------------------------------------------------------------------------
   group('FR6 #1 — valid purchase sets order status to pending', () {
-    test('order_status pending is mapped to product.orderStatus', () async {
-      _stubSelect(client, qb, [
-        _row(id: 'p1', buyerId: 'buyer-1', isSold: true, orderStatus: 'pending'),
-      ]);
+    late String p1;
 
-      final orders = await repo.fetchOrders('buyer-1');
+    setUp(() async {
+      p1 = await seedProduct(client, sellerId: sellerId, name: 'FR6 P1 Jacket');
+      await client.from('products').update({
+        'is_sold': true,
+        'buyer_id': buyerId,
+        'order_status': 'pending',
+      }).eq('id', p1);
+    });
 
-      expect(orders, hasLength(1));
-      expect(orders.first.orderStatus, equals('pending'));
-      expect(orders.first.isSold, isTrue);
+    tearDown(() async {
+      await admin.from('products').delete().eq('id', p1);
+    });
+
+    test('order_status pending is returned via fetchOrders', () async {
+      final orders = await repo.fetchOrders(buyerId);
+      final product = orders.firstWhere((p) => p.id == p1);
+      expect(product.orderStatus, equals('pending'));
+      expect(product.isSold, isTrue);
     });
 
     test('sold item is linked to buyer via buyerId field', () async {
-      _stubSelect(client, qb, [
-        _row(id: 'p1', buyerId: 'buyer-1', isSold: true, orderStatus: 'pending'),
-      ]);
-
-      final orders = await repo.fetchOrders('buyer-1');
-
-      expect(orders.first.buyerId, equals('buyer-1'));
+      final orders = await repo.fetchOrders(buyerId);
+      final product = orders.firstWhere((p) => p.id == p1);
+      expect(product.buyerId, equals(buyerId));
     });
   });
 
+  // ---------------------------------------------------------------------------
   // FR6 Partition 2 — Valid shipping update: status changes to shipped
-
+  // ---------------------------------------------------------------------------
   group('FR6 #2 — valid shipping update', () {
-    test('order_status shipped is mapped to product.orderStatus', () async {
-      _stubSelect(client, qb, [
-        _row(id: 'p1', buyerId: 'buyer-1', isSold: true, orderStatus: 'shipped'),
-      ]);
+    late String p2;
 
-      final orders = await repo.fetchOrders('buyer-1');
+    setUp(() async {
+      p2 = await seedProduct(client, sellerId: sellerId, name: 'FR6 P2 Shirt');
+      await client.from('products').update({
+        'is_sold': true,
+        'buyer_id': buyerId,
+        'order_status': 'shipped',
+      }).eq('id', p2);
+    });
 
-      expect(orders.first.orderStatus, equals('shipped'));
+    tearDown(() async {
+      await admin.from('products').delete().eq('id', p2);
+    });
+
+    test('order_status shipped is returned via fetchOrders', () async {
+      final orders = await repo.fetchOrders(buyerId);
+      final product = orders.firstWhere((p) => p.id == p2);
+      expect(product.orderStatus, equals('shipped'));
     });
 
     test('shipped item is still marked as sold', () async {
-      _stubSelect(client, qb, [
-        _row(id: 'p1', buyerId: 'buyer-1', isSold: true, orderStatus: 'shipped'),
-      ]);
-
-      final orders = await repo.fetchOrders('buyer-1');
-
-      expect(orders.first.isSold, isTrue);
-      expect(orders.first.orderStatus, equals('shipped'));
+      final orders = await repo.fetchOrders(buyerId);
+      final product = orders.firstWhere((p) => p.id == p2);
+      expect(product.isSold, isTrue);
+      expect(product.orderStatus, equals('shipped'));
     });
   });
 
+  // ---------------------------------------------------------------------------
   // FR6 Partition 3 — Valid received update: status changes to delivered
-
+  // ---------------------------------------------------------------------------
   group('FR6 #3 — valid received update', () {
-    test('order_status delivered is mapped to product.orderStatus', () async {
-      _stubSelect(client, qb, [
-        _row(id: 'p1', buyerId: 'buyer-1', isSold: true, orderStatus: 'delivered'),
-      ]);
+    late String p3;
 
-      final orders = await repo.fetchOrders('buyer-1');
-
-      expect(orders.first.orderStatus, equals('delivered'));
+    setUp(() async {
+      p3 = await seedProduct(client, sellerId: sellerId, name: 'FR6 P3 Trousers');
+      await client.from('products').update({
+        'is_sold': true,
+        'buyer_id': buyerId,
+        'order_status': 'delivered',
+      }).eq('id', p3);
     });
 
-    test('sold items fetch returns delivered status via fetchSoldItems', () async {
-      _stubSelect(client, qb, [
-        _row(id: 'p1', userId: 'seller-1', isSold: true, orderStatus: 'delivered'),
-      ]);
+    tearDown(() async {
+      await admin.from('products').delete().eq('id', p3);
+    });
 
-      final sold = await repo.fetchSoldItems('seller-1');
+    test('order_status delivered is returned via fetchOrders', () async {
+      final orders = await repo.fetchOrders(buyerId);
+      final product = orders.firstWhere((p) => p.id == p3);
+      expect(product.orderStatus, equals('delivered'));
+    });
 
-      expect(sold.first.orderStatus, equals('delivered'));
+    test('delivered status is returned via fetchSoldItems for seller', () async {
+      final sold = await repo.fetchSoldItems(sellerId);
+      final product = sold.firstWhere((p) => p.id == p3);
+      expect(product.orderStatus, equals('delivered'));
     });
   });
 
+  // ---------------------------------------------------------------------------
   // FR6 Partition 4 — View order status: system returns current tracking status
+  // ---------------------------------------------------------------------------
+  group('FR6 #4 — view order status returns all statuses correctly', () {
+    late String pPending;
+    late String pShipped;
+    late String pDelivered;
+    late String pNullStatus;
+    late String pTimestamp;
 
-  group('FR6 #4 — view order status returns all three statuses correctly', () {
-    test('all three order statuses are mapped and returned', () async {
-      _stubSelect(client, qb, [
-        _row(id: 'p1', buyerId: 'buyer-1', isSold: true, orderStatus: 'pending'),
-        _row(id: 'p2', buyerId: 'buyer-1', isSold: true, orderStatus: 'shipped'),
-        _row(id: 'p3', buyerId: 'buyer-1', isSold: true, orderStatus: 'delivered'),
-      ]);
+    setUp(() async {
+      pPending = await seedProduct(
+          client, sellerId: sellerId, name: 'FR6 P4 Pending');
+      pShipped = await seedProduct(
+          client, sellerId: sellerId, name: 'FR6 P4 Shipped');
+      pDelivered = await seedProduct(
+          client, sellerId: sellerId, name: 'FR6 P4 Delivered');
+      pNullStatus = await seedProduct(
+          client, sellerId: sellerId, name: 'FR6 P4 NullStatus');
+      pTimestamp = await seedProduct(
+          client, sellerId: sellerId, name: 'FR6 P4 Timestamp');
 
-      final orders = await repo.fetchOrders('buyer-1');
+      for (final entry in {
+        pPending: 'pending',
+        pShipped: 'shipped',
+        pDelivered: 'delivered',
+      }.entries) {
+        await client.from('products').update({
+          'is_sold': true,
+          'buyer_id': buyerId,
+          'order_status': entry.value,
+        }).eq('id', entry.key);
+      }
 
-      expect(orders, hasLength(3));
+      // Null order_status — sold but no status set.
+      await client.from('products').update({
+        'is_sold': true,
+        'buyer_id': buyerId,
+        'order_status': null,
+      }).eq('id', pNullStatus);
+
+      // Timestamp test — mark sold so it appears in fetchOrders.
+      await client.from('products').update({
+        'is_sold': true,
+        'buyer_id': buyerId,
+        'order_status': 'shipped',
+      }).eq('id', pTimestamp);
+    });
+
+    tearDown(() async {
+      await admin
+          .from('products')
+          .delete()
+          .inFilter('id', [pPending, pShipped, pDelivered, pNullStatus, pTimestamp]);
+    });
+
+    test('all three order statuses are returned in fetchOrders', () async {
+      final orders = await repo.fetchOrders(buyerId);
+      final ids = orders.map((p) => p.id).toList();
+      expect(ids, containsAll([pPending, pShipped, pDelivered]));
       expect(
-        orders.map((p) => p.orderStatus),
+        orders
+            .where((p) => [pPending, pShipped, pDelivered].contains(p.id))
+            .map((p) => p.orderStatus),
         containsAll(['pending', 'shipped', 'delivered']),
       );
     });
 
     test('null order_status maps to null — no throw', () async {
-      _stubSelect(client, qb, [
-        _row(id: 'p1', buyerId: 'buyer-1', isSold: true, orderStatus: null),
-      ]);
-
-      final orders = await repo.fetchOrders('buyer-1');
-
-      expect(orders.first.orderStatus, isNull);
+      final orders = await repo.fetchOrders(buyerId);
+      final product = orders.firstWhere((p) => p.id == pNullStatus);
+      expect(product.orderStatus, isNull);
     });
 
     test('timestamps are mapped and returned with the order', () async {
-      const ts = '2026-03-15T10:30:00.000Z';
-      _stubSelect(client, qb, [
-        _row(id: 'p1', buyerId: 'buyer-1', isSold: true, orderStatus: 'shipped', createdAt: ts),
-      ]);
-
-      final orders = await repo.fetchOrders('buyer-1');
-
-      expect(orders.first.createdAt, equals(DateTime.parse(ts)));
+      final orders = await repo.fetchOrders(buyerId);
+      final product = orders.firstWhere((p) => p.id == pTimestamp);
+      expect(product.createdAt, isNotNull);
+      expect(product.createdAt, isA<DateTime>());
     });
 
-    test('multiple orders are returned in the list', () async {
-      _stubSelect(client, qb, [
-        _row(id: 'p1', buyerId: 'buyer-1', isSold: true, orderStatus: 'pending'),
-        _row(id: 'p2', buyerId: 'buyer-1', isSold: true, orderStatus: 'delivered'),
-      ]);
-
-      final orders = await repo.fetchOrders('buyer-1');
-
-      expect(orders.map((p) => p.id), containsAll(['p1', 'p2']));
+    test('multiple orders are all returned in the list', () async {
+      final orders = await repo.fetchOrders(buyerId);
+      final ids = orders.map((p) => p.id).toList();
+      expect(ids, containsAll([pPending, pShipped, pDelivered, pNullStatus]));
     });
   });
 }

--- a/thryft/test/fr9_notifications/notification_repository_test.dart
+++ b/thryft/test/fr9_notifications/notification_repository_test.dart
@@ -1,58 +1,40 @@
-import 'dart:async';
-
 import 'package:flutter_test/flutter_test.dart';
-import 'package:mocktail/mocktail.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 import 'package:thryft/models/notification_model.dart';
+import '../helpers/supabase_test_client.dart';
+import '../helpers/seed_helper.dart';
 
-// Mocks
+const _user1Email = 'fr9.user1@thryft-test.local';
+const _user1Password = 'Thryft!test99';
 
-class MockSupabaseClient extends Mock implements SupabaseClient {}
+const _user2Email = 'fr9.user2@thryft-test.local';
+const _user2Password = 'Thryft!test99';
 
-class MockSupabaseQueryBuilder extends Mock implements SupabaseQueryBuilder {}
-
-// Fake filter builder — captures the user_id passed to .eq() so tests can
-// assert the query was scoped to the correct user.
-
-class FakeNotifFilterBuilder extends Fake
-    implements PostgrestFilterBuilder<PostgrestList> {
-  final List<dynamic> _rows;
-  final List<String?> _capturedUserIds = [];
-
-  FakeNotifFilterBuilder(this._rows);
-
-  String? get capturedUserId =>
-      _capturedUserIds.isEmpty ? null : _capturedUserIds.last;
-
-  @override
-  FakeNotifFilterBuilder eq(String column, dynamic value) {
-    if (column == 'user_id') _capturedUserIds.add(value.toString());
-    return this;
+Future<String> _signInOrSignUp(
+  SupabaseClient client,
+  String email,
+  String password,
+  String username,
+) async {
+  try {
+    final res = await client.auth.signInWithPassword(
+      email: email,
+      password: password,
+    );
+    return res.user!.id;
+  } on AuthException {
+    final res = await client.auth.signUp(
+      email: email,
+      password: password,
+      data: {'username': username},
+    );
+    return res.user!.id;
   }
-
-  @override
-  FakeNotifFilterBuilder order(
-    String column, {
-    bool ascending = false,
-    bool nullsFirst = false,
-    String? referencedTable,
-  }) =>
-      this;
-
-  @override
-  Future<U> then<U>(
-    FutureOr<U> Function(PostgrestList value) onValue, {
-    Function? onError,
-  }) =>
-      Future.value(List<PostgrestMap>.from(_rows)).then(
-        onValue,
-        onError: onError,
-      );
 }
 
-// Standalone fetch function — mirrors NotificationProvider.fetchNotifications
-// so we can test the query logic without initialising Supabase.instance.
-
+// Mirrors NotificationProvider.fetchNotifications — queries the notification
+// table scoped to a userId. Used directly here so we can test the query logic
+// against the real DB without instantiating the full provider.
 Future<List<AppNotification>> _fetchNotificationsForUser(
   SupabaseClient client,
   String userId,
@@ -67,137 +49,207 @@ Future<List<AppNotification>> _fetchNotificationsForUser(
       .toList();
 }
 
-// Helper — minimal notification DB row
-
-Map<String, dynamic> _notifRow({
-  int id = 1,
-  String userId = 'user-1',
-  String type = 'order_shipped',
-  String content = 'Notification content',
-  bool isRead = false,
-}) =>
-    {
-      'notification_id': id,
-      'user_id': userId,
-      'notif_type': type,
-      'content': content,
-      'is_read': isRead,
-      'created_at': '2026-01-01T00:00:00.000Z',
-      'listing_id': null,
-      'related_user_id': null,
-      'offer_price': null,
-      'buyer_address': null,
-    };
-
 void main() {
-  late MockSupabaseClient client;
-  late MockSupabaseQueryBuilder qb;
-  late FakeNotifFilterBuilder fakeBuilder;
-
-  void stubFetch(List<dynamic> rows) {
-    fakeBuilder = FakeNotifFilterBuilder(rows);
-    when(() => client.from('notification')).thenAnswer((_) => qb);
-    when(() => qb.select(any())).thenAnswer((_) => fakeBuilder);
+  if (!hasTestCredentials) {
+    test('FR9 integration tests', () {},
+        skip: 'No Supabase credentials — pass '
+            '--dart-define=TEST_SUPABASE_URL and TEST_SUPABASE_ANON_KEY to run');
+    return;
   }
 
-  setUp(() {
-    client = MockSupabaseClient();
-    qb = MockSupabaseQueryBuilder();
+  late SupabaseClient client;
+  late SupabaseClient admin;
+  late String user1Id;
+  late String user2Id;
+
+  setUpAll(() async {
+    client = await getTestClient();
+    admin = getServiceClient();
+
+    // Register / sign in both users; end session as user1.
+    user1Id = await _signInOrSignUp(
+        client, _user1Email, _user1Password, 'fr9_user1');
+    user2Id = await _signInOrSignUp(
+        client, _user2Email, _user2Password, 'fr9_user2');
+    await _signInOrSignUp(client, _user1Email, _user1Password, 'fr9_user1');
   });
 
-  // FR9 Partition 5 — Unrelated item update: no notification for unrelated user
+  tearDownAll(() async {
+    // Use admin client to delete all notifications seeded for both users.
+    await admin
+        .from('notification')
+        .delete()
+        .eq('user_id', user1Id);
+    await admin
+        .from('notification')
+        .delete()
+        .eq('user_id', user2Id);
+    await client.auth.signOut();
+  });
+
+  // ---------------------------------------------------------------------------
+  // FR9 Partition 5 — Only user's own notifications are returned
+  // ---------------------------------------------------------------------------
   group('FR9 #5 — only user\'s own notifications are returned', () {
+    late int notif1;
+    late int notif2;
+
+    setUp(() async {
+      notif1 = await seedNotification(admin,
+          userId: user1Id,
+          notifType: 'order_shipped',
+          content: 'Your item has been shipped');
+      notif2 = await seedNotification(admin,
+          userId: user1Id,
+          notifType: 'price_drop',
+          content: 'Price dropped on a wishlist item');
+    });
+
+    tearDown(() async {
+      await admin
+          .from('notification')
+          .delete()
+          .inFilter('notification_id', [notif1, notif2]);
+    });
+
     test('fetch returns notifications mapped for the given userId', () async {
-      stubFetch([
-        _notifRow(id: 1, userId: 'user-1', type: 'order_shipped'),
-        _notifRow(id: 2, userId: 'user-1', type: 'price_drop'),
-      ]);
-
-      final notifs = await _fetchNotificationsForUser(client, 'user-1');
-
-      expect(notifs, hasLength(2));
-      expect(notifs.every((n) => n.userId == 'user-1'), isTrue);
+      final notifs = await _fetchNotificationsForUser(client, user1Id);
+      final ids = notifs.map((n) => n.notificationId).toList();
+      expect(ids, containsAll([notif1, notif2]));
+      expect(notifs.every((n) => n.userId == user1Id), isTrue);
     });
 
     test('returns empty list for a user with no notifications', () async {
-      stubFetch([]);
-
-      final notifs = await _fetchNotificationsForUser(client, 'user-no-notifs');
-
+      // Ghost UUID — will never match any row.
+      const ghost = '00000000-ffff-4000-8000-000000000099';
+      final notifs = await _fetchNotificationsForUser(client, ghost);
       expect(notifs, isEmpty);
     });
 
     test('all returned notifications match the queried userId', () async {
-      stubFetch([
-        _notifRow(id: 1, userId: 'user-1', type: 'wishlist_purchased'),
-        _notifRow(id: 2, userId: 'user-1', type: 'listing_sold'),
-        _notifRow(id: 3, userId: 'user-1', type: 'order_delivered'),
-      ]);
-
-      final notifs = await _fetchNotificationsForUser(client, 'user-1');
-
-      expect(notifs.map((n) => n.userId), everyElement(equals('user-1')));
+      final notifs = await _fetchNotificationsForUser(client, user1Id);
+      final relevant =
+          notifs.where((n) => [notif1, notif2].contains(n.notificationId));
+      expect(relevant.map((n) => n.userId), everyElement(equals(user1Id)));
     });
   });
 
-  // FR9 Partition 8 — Access another user's notifications: access is denied
-  // The query uses eq('user_id', userId) to scope results to the current user.
-  group('FR9 #8 — query is scoped to the requesting user (not another user)', () {
-    test('query uses the correct user id in the eq filter', () async {
-      stubFetch([_notifRow(id: 1, userId: 'user-1')]);
+  // ---------------------------------------------------------------------------
+  // FR9 Partition 8 — Query is scoped to the requesting user (not another user)
+  // ---------------------------------------------------------------------------
+  group('FR9 #8 — query is scoped to the requesting user', () {
+    late int notifForUser1;
+    late int notifForUser2;
 
-      await _fetchNotificationsForUser(client, 'user-1');
-
-      expect(fakeBuilder.capturedUserId, equals('user-1'));
+    setUp(() async {
+      notifForUser1 = await seedNotification(admin,
+          userId: user1Id,
+          notifType: 'listing_sold',
+          content: 'User1 listing sold');
+      notifForUser2 = await seedNotification(admin,
+          userId: user2Id,
+          notifType: 'order_shipped',
+          content: 'User2 order shipped');
     });
 
-    test('a different userId produces a different query scope', () async {
-      stubFetch([]);
-
-      await _fetchNotificationsForUser(client, 'user-2');
-
-      expect(fakeBuilder.capturedUserId, equals('user-2'));
+    tearDown(() async {
+      await admin
+          .from('notification')
+          .delete()
+          .inFilter('notification_id', [notifForUser1, notifForUser2]);
     });
 
-    test('two separate users each get their own isolated result set', () async {
-      stubFetch([_notifRow(id: 10, userId: 'user-A', type: 'price_drop')]);
-      final notifsA = await _fetchNotificationsForUser(client, 'user-A');
-      final capturedA = fakeBuilder.capturedUserId;
+    test('signed-in user1 cannot see user2 notifications via eq filter',
+        () async {
+      // Signed in as user1; RLS + eq filter should prevent seeing user2's rows.
+      final notifs = await _fetchNotificationsForUser(client, user2Id);
+      final ids = notifs.map((n) => n.notificationId).toList();
+      expect(ids, isNot(contains(notifForUser2)));
+    });
 
-      stubFetch([_notifRow(id: 20, userId: 'user-B', type: 'order_shipped')]);
-      final notifsB = await _fetchNotificationsForUser(client, 'user-B');
-      final capturedB = fakeBuilder.capturedUserId;
+    test('signed-in user1 can fetch their own notifications', () async {
+      final notifs = await _fetchNotificationsForUser(client, user1Id);
+      final ids = notifs.map((n) => n.notificationId).toList();
+      expect(ids, contains(notifForUser1));
+    });
 
-      expect(capturedA, equals('user-A'));
-      expect(capturedB, equals('user-B'));
-      expect(notifsA.first.userId, equals('user-A'));
-      expect(notifsB.first.userId, equals('user-B'));
+    test('switching session gives each user access to only their own data',
+        () async {
+      // user1 sees their notification.
+      final user1Notifs = await _fetchNotificationsForUser(client, user1Id);
+      expect(
+        user1Notifs.map((n) => n.notificationId),
+        contains(notifForUser1),
+      );
+
+      // Sign in as user2 and verify they see their own, not user1's.
+      await _signInOrSignUp(
+          client, _user2Email, _user2Password, 'fr9_user2');
+      final user2Notifs = await _fetchNotificationsForUser(client, user2Id);
+      expect(
+        user2Notifs.map((n) => n.notificationId),
+        contains(notifForUser2),
+      );
+      expect(
+        user2Notifs.map((n) => n.notificationId),
+        isNot(contains(notifForUser1)),
+      );
+
+      // Restore session as user1 for remaining tests.
+      await _signInOrSignUp(
+          client, _user1Email, _user1Password, 'fr9_user1');
     });
   });
 
-  // Boundary — large notification sets
-  group('FR9 — large notification set boundary', () {
-    List<Map<String, dynamic>> _makeRows(int count) => List.generate(
-          count,
-          (i) => _notifRow(id: i + 1, userId: 'user-1', type: 'price_drop'),
-        );
+  // ---------------------------------------------------------------------------
+  // FR9 — Notification count boundary
+  // ---------------------------------------------------------------------------
+  group('FR9 — notification count boundary', () {
+    late List<int> seededIds;
+
+    tearDown(() async {
+      if (seededIds.isNotEmpty) {
+        await admin
+            .from('notification')
+            .delete()
+            .inFilter('notification_id', seededIds);
+      }
+    });
 
     test('1 notification — mapped correctly', () async {
-      stubFetch(_makeRows(1));
-      final notifs = await _fetchNotificationsForUser(client, 'user-1');
-      expect(notifs, hasLength(1));
+      seededIds = [
+        await seedNotification(admin,
+            userId: user1Id,
+            notifType: 'price_drop',
+            content: 'Boundary: 1 notification'),
+      ];
+
+      final notifs = await _fetchNotificationsForUser(client, user1Id);
+      expect(
+        notifs.map((n) => n.notificationId),
+        contains(seededIds.first),
+      );
     });
 
-    test('50 notifications — all mapped', () async {
-      stubFetch(_makeRows(50));
-      final notifs = await _fetchNotificationsForUser(client, 'user-1');
-      expect(notifs, hasLength(50));
-    });
+    test('3 notifications — all mapped', () async {
+      seededIds = await Future.wait([
+        seedNotification(admin,
+            userId: user1Id,
+            notifType: 'order_shipped',
+            content: 'Boundary notif 1'),
+        seedNotification(admin,
+            userId: user1Id,
+            notifType: 'order_delivered',
+            content: 'Boundary notif 2'),
+        seedNotification(admin,
+            userId: user1Id,
+            notifType: 'listing_sold',
+            content: 'Boundary notif 3'),
+      ]);
 
-    test('51 notifications — all mapped (no cutoff)', () async {
-      stubFetch(_makeRows(51));
-      final notifs = await _fetchNotificationsForUser(client, 'user-1');
-      expect(notifs, hasLength(51));
+      final notifs = await _fetchNotificationsForUser(client, user1Id);
+      final returnedIds = notifs.map((n) => n.notificationId).toList();
+      expect(returnedIds, containsAll(seededIds));
     });
   });
 }

--- a/thryft/test/fr9_notifications/notification_repository_test.dart
+++ b/thryft/test/fr9_notifications/notification_repository_test.dart
@@ -10,8 +10,11 @@ const _user1Password = 'Thryft!test99';
 const _user2Email = 'fr9.user2@thryft-test.local';
 const _user2Password = 'Thryft!test99';
 
+// Uses the admin client to create the user when they don't exist yet,
+// bypassing email confirmation and avoiding rate limits.
 Future<String> _signInOrSignUp(
   SupabaseClient client,
+  SupabaseClient admin,
   String email,
   String password,
   String username,
@@ -23,10 +26,15 @@ Future<String> _signInOrSignUp(
     );
     return res.user!.id;
   } on AuthException {
-    final res = await client.auth.signUp(
+    await admin.auth.admin.createUser(AdminUserAttributes(
       email: email,
       password: password,
-      data: {'username': username},
+      emailConfirm: true,
+      userMetadata: {'username': username},
+    ));
+    final res = await client.auth.signInWithPassword(
+      email: email,
+      password: password,
     );
     return res.user!.id;
   }
@@ -68,10 +76,10 @@ void main() {
 
     // Register / sign in both users; end session as user1.
     user1Id = await _signInOrSignUp(
-        client, _user1Email, _user1Password, 'fr9_user1');
+        client, admin, _user1Email, _user1Password, 'fr9_user1');
     user2Id = await _signInOrSignUp(
-        client, _user2Email, _user2Password, 'fr9_user2');
-    await _signInOrSignUp(client, _user1Email, _user1Password, 'fr9_user1');
+        client, admin, _user2Email, _user2Password, 'fr9_user2');
+    await _signInOrSignUp(client, admin, _user1Email, _user1Password, 'fr9_user1');
   });
 
   tearDownAll(() async {
@@ -184,7 +192,7 @@ void main() {
 
       // Sign in as user2 and verify they see their own, not user1's.
       await _signInOrSignUp(
-          client, _user2Email, _user2Password, 'fr9_user2');
+          client, admin, _user2Email, _user2Password, 'fr9_user2');
       final user2Notifs = await _fetchNotificationsForUser(client, user2Id);
       expect(
         user2Notifs.map((n) => n.notificationId),
@@ -197,7 +205,7 @@ void main() {
 
       // Restore session as user1 for remaining tests.
       await _signInOrSignUp(
-          client, _user1Email, _user1Password, 'fr9_user1');
+          client, admin, _user1Email, _user1Password, 'fr9_user1');
     });
   });
 

--- a/thryft/test/helpers/seed_helper.dart
+++ b/thryft/test/helpers/seed_helper.dart
@@ -120,6 +120,37 @@ Future<int> seedOffer(
   return response['offer_id'] as int;
 }
 
+/// Inserts a row into [notification] and returns the notification_id.
+///
+/// Pass the service-role client to bypass RLS insert policies.
+Future<int> seedNotification(
+  SupabaseClient client, {
+  required String userId,
+  String notifType = 'order_shipped',
+  String content = 'Test notification',
+  bool isRead = false,
+  String? listingId,
+  String? relatedUserId,
+  double? offerPrice,
+  String? buyerAddress,
+}) async {
+  final response = await client
+      .from('notification')
+      .insert({
+        'user_id': userId,
+        'notif_type': notifType,
+        'content': content,
+        'is_read': isRead,
+        if (listingId != null) 'listing_id': listingId,
+        if (relatedUserId != null) 'related_user_id': relatedUserId,
+        if (offerPrice != null) 'offer_price': offerPrice,
+        if (buyerAddress != null) 'buyer_address': buyerAddress,
+      })
+      .select('notification_id')
+      .single();
+  return response['notification_id'] as int;
+}
+
 /// Inserts a row into [ratings] and returns the rating id.
 Future<String> seedRating(
   SupabaseClient client, {


### PR DESCRIPTION
This pull request refactors the FR6 order status and FR9 notification repository tests to use real Supabase integration tests instead of mock-based, in-memory tests. The changes remove all mock and fake classes, replacing them with actual database operations using seeded test users and products. This approach ensures that tests now validate real-world behavior with Supabase, improving reliability and coverage.

Key changes include:

**Migration to integration tests:**

- Replaced all mock and fake Supabase client/query builder classes with real Supabase client instances, using helper files (`supabase_test_client.dart`, `seed_helper.dart`) for test setup and teardown. Test users and products are created and cleaned up in the database for each test run. [[1]](diffhunk://#diff-5b753d31d49401cc51e29623c90c15eed8729f2858f94c9976365eb5d4ea9b76L1-R259) [[2]](diffhunk://#diff-5bccc92e51684784faaa90eaba5a5dc585349ee5fbdebd8f2e8821ba5518c4caL1-R45)
- Added helper methods (`_signInOrSignUp`) to programmatically create or sign in test users, bypassing email confirmation and rate limits by using the Supabase admin client. [[1]](diffhunk://#diff-5b753d31d49401cc51e29623c90c15eed8729f2858f94c9976365eb5d4ea9b76L1-R259) [[2]](diffhunk://#diff-5bccc92e51684784faaa90eaba5a5dc585349ee5fbdebd8f2e8821ba5518c4caL1-R45)

**Test structure and coverage improvements:**

- Each FR6 order status test partition now seeds actual products and updates their state in the database to simulate real order flows (pending, shipped, delivered, null status). Tests assert against real data returned from the repository.
- Notification repository tests now also use real users and database records, ensuring queries are properly scoped and results reflect the actual database state.

**Test reliability and cleanup:**

- Added setup and teardown logic to ensure test data is created before and removed after each test suite, preventing data leakage between tests and ensuring repeatability. [[1]](diffhunk://#diff-5b753d31d49401cc51e29623c90c15eed8729f2858f94c9976365eb5d4ea9b76L1-R259) [[2]](diffhunk://#diff-5bccc92e51684784faaa90eaba5a5dc585349ee5fbdebd8f2e8821ba5518c4caL1-R45)

These changes significantly increase the robustness and realism of the test suites by exercising the actual Supabase integration rather than relying on in-memory mocks.

- Migration from mock-based to real integration tests using Supabase test helpers and seeded data. [[1]](diffhunk://#diff-5b753d31d49401cc51e29623c90c15eed8729f2858f94c9976365eb5d4ea9b76L1-R259) [[2]](diffhunk://#diff-5bccc92e51684784faaa90eaba5a5dc585349ee5fbdebd8f2e8821ba5518c4caL1-R45)
- Helper methods for creating/signing in test users with admin privileges to streamline setup and avoid rate limits. [[1]](diffhunk://#diff-5b753d31d49401cc51e29623c90c15eed8729f2858f94c9976365eb5d4ea9b76L1-R259) [[2]](diffhunk://#diff-5bccc92e51684784faaa90eaba5a5dc585349ee5fbdebd8f2e8821ba5518c4caL1-R45)
- Refactored FR6 order status tests to update and assert real product/order states