### PR TITLE
Fix notification model null safety and update FR4 test expectations

### DIFF
--- a/thryft/lib/models/notification_model.dart
+++ b/thryft/lib/models/notification_model.dart
@@ -103,9 +103,13 @@ class AppNotification {
 
   // builds a notification from a supabase row
   factory AppNotification.fromMap(Map<String, dynamic> map) {
+    final userId = map['user_id'];
+    if (userId == null) {
+      throw ArgumentError('notification row is missing user_id');
+    }
     return AppNotification(
       notificationId: map['notification_id'] as int,
-      userId: map['user_id'].toString(),
+      userId: userId.toString(),
       notifType: NotificationType.fromString(map['notif_type'].toString()),
       content: map['content'].toString(),
       isRead: map['is_read'] as bool? ?? false,

--- a/thryft/test/fr4_edit_manage_listings/listing_repository_test.dart
+++ b/thryft/test/fr4_edit_manage_listings/listing_repository_test.dart
@@ -294,7 +294,7 @@ void main() {
   // verify the row is unchanged after the call, not that an exception is thrown.
   // -------------------------------------------------------------------------
   group("FR4 #5 — edit another user's listing", () {
-    test("update on a non-owned product does nothing (RLS silently filters)",
+    test("update on a non-owned product is rejected and price is unchanged",
         () async {
       // Get original price while signed in as seller.
       final originalRow = await client
@@ -303,20 +303,24 @@ void main() {
           .eq('id', productId)
           .single();
 
-      // Sign in as the buyer — they don't own productId, so RLS should
-      // silently filter the update (0 rows affected, no exception thrown).
+      // Sign in as the buyer — they don't own productId, so the
+      // enforce_buyer_update_columns trigger should raise when we try to
+      // change a non-sale column like price.
       await client.auth.signInWithPassword(
         email: _buyerEmail,
         password: _buyerPassword,
       );
 
-      await repo.updateListing(
-        id: productId,
-        userId: buyerId,
-        fields: {'price': 9999.0},
+      await expectLater(
+        repo.updateListing(
+          id: productId,
+          userId: buyerId,
+          fields: {'price': 9999.0},
+        ),
+        throwsA(isA<PostgrestException>()),
       );
 
-      // Sign back in as seller to verify the row.
+      // Sign back in as seller to verify the row is unchanged.
       await _ensureSignedIn(client);
 
       final afterRow = await client


### PR DESCRIPTION
## Summary

This PR makes two targeted changes:

### Notification Model – Null Safety Fix
- Updated `Notification.fromMap()` to **throw** if `user_id` is null instead of silently accepting it, improving data integrity and error visibility.

### FR4 Test Update
- Updated FR4 #5 test to expect the new error behaviour, since buyers can no longer edit price.

## Files Changed
| File | Changes |
|------|---------|
| `thryft/lib/models/notification_model.dart` | Enforce non-null `user_id` in `fromMap` |
| `thryft/test/.../listing_repository_test.dart` | Update test expectations for buyer price-edit restriction |

**2 files changed**, 17 insertions, 9 deletions.