### PR TITLE
Restore requireAuth redirect guard and clean up duplicate route

### DIFF
--- a/thryft/lib/router.dart
+++ b/thryft/lib/router.dart
@@ -79,16 +79,6 @@ final GoRouter router = GoRouter(
       redirect: (context, state) => requireAuth(Supabase.instance.client),
       builder: (context, state) => const MyOrdersScreen(),
     ),
-
-     GoRoute(
-      path: '/my-offers',
-      builder: (context, state) => const MyOffersScreen(),
-    ),
-    
-    GoRoute(
-      path: '/my-offers',
-      builder: (context, state) => const MyOffersScreen(),
-    ),
     GoRoute(
       path: '/sold-items',
       redirect: (context, state) => requireAuth(Supabase.instance.client),

--- a/thryft/lib/router.dart
+++ b/thryft/lib/router.dart
@@ -1,4 +1,5 @@
 import 'package:go_router/go_router.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
 import 'package:thryft/screens/about_screen.dart';
 import 'package:thryft/screens/contact_screen.dart';
 import 'package:thryft/screens/help_center_screen.dart';
@@ -23,6 +24,9 @@ import 'package:thryft/screens/forgot_password_screen.dart';
 import 'package:thryft/screens/my_offers_screen.dart';
 import 'package:thryft/screens/nav_assistant_chat_screen.dart';
 import 'package:thryft/screens/search_screen.dart';
+
+String? requireAuth(SupabaseClient client) =>
+    client.auth.currentUser == null ? '/auth' : null;
 
 final GoRouter router = GoRouter(
   initialLocation: '/',

--- a/thryft/lib/router.dart
+++ b/thryft/lib/router.dart
@@ -63,6 +63,7 @@ final GoRouter router = GoRouter(
     ),
     GoRoute(
       path: '/create-listing',
+      redirect: (context, state) => requireAuth(Supabase.instance.client),
       builder: (context, state) {
         final data = state.extra as Map<String, dynamic>?;
         return CreateListingScreen(initialData: data);
@@ -70,10 +71,12 @@ final GoRouter router = GoRouter(
     ),
     GoRoute(
       path: '/my-listings',
+      redirect: (context, state) => requireAuth(Supabase.instance.client),
       builder: (context, state) => const MyListingsScreen(),
     ),
     GoRoute(
       path: '/my-orders',
+      redirect: (context, state) => requireAuth(Supabase.instance.client),
       builder: (context, state) => const MyOrdersScreen(),
     ),
 
@@ -88,6 +91,7 @@ final GoRouter router = GoRouter(
     ),
     GoRoute(
       path: '/sold-items',
+      redirect: (context, state) => requireAuth(Supabase.instance.client),
       builder: (context, state) => const SoldItemsScreen(),
     ),
     GoRoute(


### PR DESCRIPTION
## Summary
- restore the `requireAuth` helper and `supabase_flutter` import that were dropped from `thryft/lib/router.dart` during the `481be3f` merge
- re-apply the `redirect:` guard on the four protected routes (`/create-listing`, `/my-listings`, `/my-orders`, `/sold-items`) so logged-out users get sent to `/auth`
- remove two stray `/my-offers` `GoRoute` entries the same merge left behind

Restores the 8 redirect tests for FR4 #9, FR5 #6, FR6 #7, and FR6 #8 — they were failing to compile on `main` with `Error: Method not found: 'requireAuth'`.


